### PR TITLE
fix: quotations

### DIFF
--- a/src/Surl.sol
+++ b/src/Surl.sol
@@ -99,7 +99,7 @@ library Surl {
         curlParams = string.concat(curlParams, " -X ", method, " ");
 
         if (bytes(body).length > 0) {
-            curlParams = string.concat(curlParams, ' -d "', body, '" ');
+            curlParams = string.concat(curlParams, ' -d \'', body, '\' ');
         }
 
         string memory quotedURL = string.concat('"', self, '"');

--- a/test/Surl.t.sol
+++ b/test/Surl.t.sol
@@ -70,8 +70,8 @@ contract SurlTest is Test {
 
         assertEq(status, 200);
         strings.slice memory responseText = string(data).toSlice();
-        assertTrue(responseText.contains(("foo").toSlice()));
-        assertTrue(responseText.contains(("bar").toSlice()));
+        assertTrue(responseText.contains(('"foo"').toSlice()));
+        assertTrue(responseText.contains(('"bar"').toSlice()));
     }
 
     function testDelete() public {


### PR DESCRIPTION
Fixes https://github.com/memester-xyz/surl/issues/7

~~A bit tedious to test (could do it by parsing the response JSON) but I didn't have the time to do that, so here is proof it fixes the issue:~~ Updated test to just look for quotes around `foo` and `bar`, leaving the below for posterity

### Before this PR

**Curl input**: notice the quotes in the data are not properly escaped

![image](https://user-images.githubusercontent.com/17163988/225188665-52f3c1c1-9e63-46fd-900b-3e7aaf1b6c91.png)

**ffi response data**: Notice the `"{foo: bar}"`, i.e. they keys are no longer quoted

```
$ cast 2as 0x7b20202261726773223a207b7d2c2020202264617461223a20227b666f6f3a206261727d222c2020202266696c6573223a207b7d2c20202022666f726d223a207b7d2c2020202268656164657273223a207b2020202022416363657074223a20222a2f2a222c202020202022436f6e74656e742d4c656e677468223a20223130222c202020202022436f6e74656e742d54797065223a20226170706c69636174696f6e2f6a736f6e222c202020202022486f7374223a20226874747062696e2e6f7267222c202020202022557365722d4167656e74223a20226375726c2f372e38342e30222c202020202022582d416d7a6e2d54726163652d4964223a2022526f6f743d312d36343131323532312d3632396335343830373365633233356632393437373464382220207d2c202020226a736f6e223a206e756c6c2c202020226f726967696e223a20223130382e3138342e31352e3432222c2020202275726c223a202268747470733a2f2f6874747062696e2e6f72672f706f7374227d
{  "args": {},   "data": "{foo: bar}",   "files": {},   "form": {},   "headers": {    "Accept": "*/*",     "Content-Length": "10",     "Content-Type": "application/json",     "Host": "httpbin.org",     "User-Agent": "curl/7.84.0",     "X-Amzn-Trace-Id": "Root=1-64112521-629c548073ec235f294774d8"  },   "json": null,   "origin": "108.184.15.42",   "url": "https://httpbin.org/post"}
```





### Response data after this PR

**Curl input**: switch to single quotes fixes the inner double quotes

![image](https://user-images.githubusercontent.com/17163988/225188648-26b81ab5-aa80-4e53-8e23-bd73cba98185.png)

**ffi response data**": now has escaped quotes

```
$ cast 2as 0x7b20202261726773223a207b7d2c2020202264617461223a20227b5c22666f6f5c223a205c226261725c227d222c2020202266696c6573223a207b7d2c20202022666f726d223a207b7d2c2020202268656164657273223a207b2020202022416363657074223a20222a2f2a222c202020202022436f6e74656e742d4c656e677468223a20223134222c202020202022436f6e74656e742d54797065223a20226170706c69636174696f6e2f6a736f6e222c202020202022486f7374223a20226874747062696e2e6f7267222c202020202022557365722d4167656e74223a20226375726c2f372e38342e30222c202020202022582d416d7a6e2d54726163652d4964223a2022526f6f743d312d36343131323663322d3233663839303963366361353435363834313262623664632220207d2c202020226a736f6e223a207b2020202022666f6f223a20226261722220207d2c202020226f726967696e223a20223130382e3138342e31352e3432222c2020202275726c223a202268747470733a2f2f6874747062696e2e6f72672f706f7374227d
{  "args": {},   "data": "{\"foo\": \"bar\"}",   "files": {},   "form": {},   "headers": {    "Accept": "*/*",     "Content-Length": "14",     "Content-Type": "application/json",     "Host": "httpbin.org",     "User-Agent": "curl/7.84.0",     "X-Amzn-Trace-Id": "Root=1-641126c2-23f8909c6ca54568412bb6dc"  },   "json": {    "foo": "bar"  },   "origin": "108.184.15.42",   "url": "https://httpbin.org/post"}
```




Note the change from `"data": "{foo: bar}"` to `"data": "{\"foo\": \"bar\"}"`

